### PR TITLE
Fixes shouldjs/should.js#45 - Object #<Object> has no method 'isString' ...

### DIFF
--- a/lib/ext/property.js
+++ b/lib/ext/property.js
@@ -346,7 +346,7 @@ module.exports = function(should, Assertion) {
    */
   Assertion.add('propertyByPath', function(properties) {
     if(arguments.length > 1) properties = aSlice.call(arguments);
-    else if(arguments.length === 1 && util.isString(properties)) properties = [properties];
+    else if(arguments.length === 1 && typeof properties == 'string') properties = [properties];
     else if(arguments.length === 0) properties = [];
 
     var allProps = properties.map(util.formatProp);

--- a/test/ext/property.test.js
+++ b/test/ext/property.test.js
@@ -231,14 +231,27 @@ describe('property', function() {
 
     ({ '0': { '0': 10}}).should.not.have.propertyByPath(0, 0, 1);
 
+    ({ a: { b: 10}}).should.have.propertyByPath('a');
+
     // true fail
     err(function() {
       ({ a: { b: 10}}).should.have.propertyByPath('a', 'b', 'c');
     }, "expected { a: { b: 10 } } to have property by path a, b, c - failed on c\n    expected 10 to have property c");
 
+    // true fail
+    err(function() {
+      ({ a: { b: 10}}).should.have.propertyByPath('z');
+    }, "expected { a: { b: 10 } } to have property by path z - failed on z\n    expected { a: { b: 10 } } to have property z");
+
     // false positive
     err(function() {
       ({ a: { b: 10}}).should.not.have.propertyByPath('a', 'b');
     }, "expected { a: { b: 10 } } not to have property by path a, b (false negative fail)");
+
+    // false positive
+    err(function() {
+      ({ a: { b: 10}}).should.not.have.propertyByPath('a');
+    }, "expected { a: { b: 10 } } not to have property by path a (false negative fail)");
+
   })
 });


### PR DESCRIPTION
...when calling propertyByPath with String argument instead of Array

Added test cases for calling propertyByPath with string