### PR TITLE
Add/matchAny

### DIFF
--- a/lib/ext/match.js
+++ b/lib/ext/match.js
@@ -162,4 +162,60 @@ module.exports = function(should, Assertion) {
       }
     }, this);
   });
+
+  /**
+  * Asserts if given any of object values or array elements match `other` object, using some assumptions:
+  * First object matched if they are equal,
+  * If `other` is a regexp - matching with regexp
+  * If `other` is a function check if this function throws AssertionError on given object or return false - it will be assumed as not matched
+  * All other cases check if this `other` equal to each element
+  *
+  * @name matchAny
+  * @memberOf Assertion
+  * @category assertion matching
+  * @param {*} other Object to match
+  * @param {string} [description] Optional message
+  * @example
+  * [ 'a', 'b', 'c'].should.matchAny(/\w+/);
+  * [ 'a', 'b', 'c'].should.matchAny('a');
+  *
+  * [ 'a', 'b', 'c'].should.matchAny(function(value) { value.should.be.eql('a') });
+  *
+  * { a: 'a', b: 'b', c: 'c' }.should.matchAny(function(value) { value.should.be.eql('a') });
+  */
+  Assertion.add('matchAny', function(other, description) {
+      this.params = {operator: 'to match any ' + i(other), message: description};
+
+      var f = other;
+
+      if(other instanceof RegExp) {
+          f = function(it) {
+              return !!other.exec(it);
+          };
+      } else if(typeof other != 'function') {
+          f = function(it) {
+              return eql(it, other).result;
+          };
+      }
+
+      this.assert(util.some(this.obj, function(value, key) {
+          try {
+              var result = f(value, key);
+
+              if(typeof result == 'boolean') {
+                  return result; // if it is just boolean, return it
+              }
+
+              // Else return true - no exception was thrown, so assume it succeeded
+              return true;
+          } catch(e) {
+              if(e instanceof should.AssertionError) {
+                  // Caught an AssertionError, return false to the iterator
+                  return false;
+              } else {
+                  throw e;
+              }
+          }
+      }, this));
+  });
 };

--- a/lib/ext/match.js
+++ b/lib/ext/match.js
@@ -164,7 +164,7 @@ module.exports = function(should, Assertion) {
   });
 
   /**
-  * Asserts if given any of object values or array elements match `other` object, using some assumptions:
+  * Asserts if any of given object values or array elements match `other` object, using some assumptions:
   * First object matched if they are equal,
   * If `other` is a regexp - matching with regexp
   * If `other` is a function check if this function throws AssertionError on given object or return false - it will be assumed as not matched

--- a/test/ext/match.test.js
+++ b/test/ext/match.test.js
@@ -147,4 +147,44 @@ describe('match', function() {
       [10, 11].should.matchEach(10);
     }, "expected [ 10, 11 ] to match each 10");
   });
+
+  it('test matchAny(function)', function() {
+      [9, 10, 11].should.matchAny(function(it) {
+          return it >= 10;
+      });
+
+      [9, 10, 11].should.not.matchAny(function(it) {
+          return it == 2;
+      });
+
+      ({ a: 10, b: 11, c: 12}).should.matchAny(function(value, key) {
+          value.should.be.a.Number;
+      });
+
+      ({ a: 10, b: 'eleven', c: 'twelve'}).should.matchAny(function(value, key) {
+          value.should.be.a.Number;
+      });
+  });
+
+  it('test matchAny(number)', function() {
+      [10, 11, 12].should.matchAny(10);
+
+      [10, 10].should.matchAny(10);
+
+      [10, 11, 12].should.not.matchAny(2);
+  });
+
+  it('test matchAny(regexp)', function() {
+      (['a', 'b', 'c']).should.matchAny(/[a-b]/);
+
+      (['a', 'b', 'c']).should.not.matchAny(/[d-f]/);
+
+      err(function() {
+          (['a', 'b', 'c']).should.not.matchAny(/[a-c]/);
+      }, "expected [ 'a', 'b', 'c' ] not to match any /[a-c]/ (false negative fail)");
+
+      err(function() {
+          [8, 9].should.matchAny(10);
+      }, "expected [ 8, 9 ] to match any 10");
+  });
 });


### PR DESCRIPTION
Adds the `matchAny` assertion, for testing if one or more object values or array elements match a given value/regexp/function.

Fixes #52 