### PR TITLE
remove version tag from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "should",
   "main": "should.js",
-  "version": "5.0.0",
+  "version": "5.2.0",
   "homepage": "https://github.com/shouldjs/should.js",
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "should",
   "main": "should.js",
-  "version": "5.2.0",
   "homepage": "https://github.com/shouldjs/should.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`version` can be removed like mentioned in [bower.json spec](https://github.com/bower/bower.json-spec):

> Ignored by Bower as git tags are used instead.
> Intended to be used in the future when Bower gets a real registry where you can publish actual
> packages, but for now just leave it out.