### PR TITLE
alias .deepEqual to .eql

### DIFF
--- a/lib/ext/eql.js
+++ b/lib/ext/eql.js
@@ -72,4 +72,5 @@ module.exports = function(should, Assertion) {
   });
 
   Assertion.alias('equal', 'exactly');
+  Assertion.alias('eql', 'deepEqual');
 };


### PR DESCRIPTION
Because we have `should.deepEqual()` and `should().eql()` but no `should().deepEqual()`.

---

As well, `should().equal()` and `should().eql()` are ambiguous when mixed with each other:

```javascript
([1234]).should.equal([1234]);      // error
([1234]).should.eql([1234]);        // ok
```

whereas

```javascript
([1234]).should.equal([1234]);      // error
([1234]).should.deepEqual([1234]);  // ok
```

makes more sense when reading through code.

---

I didn't add tests because `should().exactly()` doesn't have any either.

```shell
$ cd test && grep -r "exactly" * | wc -l
0
```

I can add some if you'd like.