### PR TITLE
Document a callback as `properties` in `should.throw()` assertion

### DIFF
--- a/lib/ext/error.js
+++ b/lib/ext/error.js
@@ -16,7 +16,8 @@ module.exports = function(should, Assertion) {
    * @category assertion errors
    * @alias Assertion#throwError
    * @param {string|RegExp|Function|Object|GeneratorFunction|GeneratorObject} [message] Message to match or properties
-   * @param {Object} [properties] Optional properties that will be matched to thrown error
+   * @param {Object|Function} [properties] Optional properties that will be matched to thrown error,
+   *  or function which receives the error and verifies it by returning a boolean.
    * @example
    *
    * (function(){ throw new Error('fail') }).should.throw();
@@ -31,6 +32,9 @@ module.exports = function(should, Assertion) {
    * (function*() {
    *   yield throwError();
    * }).should.throw();
+   * (function(){ throw new Error('fail') }).should.throw(Error, function(err) {
+   *   return /fail/.test(err.message);
+   * });
    */
   Assertion.add('throw', function(message, properties) {
     var fn = this.obj

--- a/test/ext/error.test.js
+++ b/test/ext/error.test.js
@@ -128,6 +128,22 @@ describe('error', function() {
       (function(){ throw error; }).should.throw({ a: 11 });
     }, /expected Function \{ name: '' \} to throw exception: expected Error \{[\s\S]*a: 10,[\s\S]*message: ''[\s\S]*\} to match Object \{ a: 11 \}\n    not matched properties: a \(10\)/);
   });
+
+  it('test .throw(err, callback)', function() {
+    var error = new Error();
+    error.a = 10;
+    (function(){ throw error; }).should.throw(Error, function(_error) {
+      return (_error.a > 5);
+    });
+
+    // AssertionError: expected Function { name: '' } to throw exception: expected Error { message: 'fail' } to match Function { name: '' }
+    err(function() {
+      (function () { throw error; }).should.throw(Error, function (_error) {
+        return (_error.a > 11);
+      })
+    }, /expected Function \{ name: '' \} to throw exception: expected Error \{[\s\S]*a: 10,[\s\S]*message: ''[\s\S]*\} to match Function \{ name: '' \}/);
+  });
+
 /* TODO find a way to write tests with es6 features
   it('should support to catch errors from generators', function() {
     if(generatorSupported) {


### PR DESCRIPTION
It appears that `.should.throw()` has an undocumented ability to take a [synchronous] callback as the 2nd parameter, and verify arbitrary properties on the Error instance.

Example:

```javascript
(function(){
  var err = new Error();
  err.a = 10;
}).should.throw(Error, function(err) {
  return (err.a > 5);    // passes
  // OR
  return (err.a > 11);  // fails
});
```

Is this an intended feature, or an unintended side effect of something else?

Assuming this is in fact intended and/or wanted, this PR documents the feature and adds a test for it.

Thank you.