### PR TITLE
Fix matchSome and matchEvery documentation

### DIFF
--- a/lib/ext/match.js
+++ b/lib/ext/match.js
@@ -147,7 +147,7 @@ module.exports = function(should, Assertion) {
    * @name matchEach
    * @memberOf Assertion
    * @category assertion matching
-   * @alias Assertion#matchSome
+   * @alias Assertion#matchEvery
    * @param {*} other Object to match
    * @param {string} [description] Optional message
    * @example
@@ -177,7 +177,7 @@ module.exports = function(should, Assertion) {
   * @memberOf Assertion
   * @category assertion matching
   * @param {*} other Object to match
-  * @alias Assertion#matchEvery
+  * @alias Assertion#matchSome
   * @param {string} [description] Optional message
   * @example
   * [ 'a', 'b', 'c'].should.matchAny(/\w+/);


### PR DESCRIPTION
Swap aliases in `matchAny` and `matchEach` in-code documentation