### PR TITLE
Fixes documentation typo: thuthy should be truthy.

### DIFF
--- a/lib/ext/bool.js
+++ b/lib/ext/bool.js
@@ -47,7 +47,7 @@ export default function(should, Assertion) {
   Assertion.alias('false', 'False');
 
   /**
-   * Assert given object is thuthy according javascript type conversions.
+   * Assert given object is truthy according javascript type conversions.
    *
    * @name ok
    * @memberOf Assertion

--- a/should.js
+++ b/should.js
@@ -1940,7 +1940,7 @@
     Assertion.alias('false', 'False');
 
     /**
-     * Assert given object is thuthy according javascript type conversions.
+     * Assert given object is truthy according javascript type conversions.
      *
      * @name ok
      * @memberOf Assertion


### PR DESCRIPTION
#### What's this PR do?
- Fixes typo in documentation: thuthy should be [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy).
- Minor: Adds a newline at the end of `should.js`

#### Why This Matters
I got confused while searching for `truthy` in http://shouldjs.github.io/ docs. I knew it was there, but couldn't find it.