### PR TITLE
Add for readability: equals, eqls

### DIFF
--- a/lib/ext/eql.js
+++ b/lib/ext/eql.js
@@ -26,6 +26,7 @@ export default function(should, Assertion) {
    * @name eql
    * @memberOf Assertion
    * @category assertion equality
+   * @alias Assertion#eqls
    * @alias Assertion#deepEqual
    * @param {*} val Expected value
    * @param {string} [description] Optional message
@@ -59,6 +60,7 @@ export default function(should, Assertion) {
    * @name equal
    * @memberOf Assertion
    * @category assertion equality
+   * @alias Assertion#equals
    * @alias Assertion#exactly
    * @param {*} val Expected value
    * @param {string} [description] Optional message
@@ -77,7 +79,9 @@ export default function(should, Assertion) {
     this.assert(val === this.obj);
   });
 
+  Assertion.alias('equal', 'equals');
   Assertion.alias('equal', 'exactly');
+  Assertion.alias('eql', 'eqls');
   Assertion.alias('eql', 'deepEqual');
 
   function addOneOf(name, message, method) {


### PR DESCRIPTION
This is just an itch. Helpful for lines like:

`({a: 1}).should.have.property('a').which.equals(1);`

Happy to add unit tests, didn't see any for `.exactly()` alias so skipped (no need to test that aliasing works).