### PR TITLE
fix error message for aboveOrEqual & belowOrEqual

### DIFF
--- a/lib/ext/number.js
+++ b/lib/ext/number.js
@@ -136,7 +136,7 @@ export default function(should, Assertion) {
    * (10).should.be.aboveOrEqual(10);
    */
   Assertion.add('aboveOrEqual', function(n, description) {
-    this.params = { operator: 'to be above or equal' + n, message: description };
+    this.params = { operator: 'to be above or equal ' + n, message: description };
 
     this.assert(this.obj >= n);
   });
@@ -156,7 +156,7 @@ export default function(should, Assertion) {
    * (0).should.be.belowOrEqual(0);
    */
   Assertion.add('belowOrEqual', function(n, description) {
-    this.params = { operator: 'to be below or equal' + n, message: description };
+    this.params = { operator: 'to be below or equal ' + n, message: description };
 
     this.assert(this.obj <= n);
   });

--- a/test/ext/number.test.js
+++ b/test/ext/number.test.js
@@ -129,11 +129,19 @@ describe('number', function() {
     (5).should.be.aboveOrEqual(2);
     (5).should.be.aboveOrEqual(5);
     (5).should.not.be.aboveOrEqual(6);
+
+    err(function() {
+      (5).should.be.aboveOrEqual(6);
+    }, 'expected 5 to be above or equal 6');
   });
 
   it('test belowOrEqual(n)', function() {
     (2).should.be.belowOrEqual(5);
     (5).should.be.belowOrEqual(5);
     (6).should.not.be.belowOrEqual(5);
+
+    err(function() {
+      (6).should.be.belowOrEqual(5);
+    }, 'expected 6 to be below or equal 5');
   });
 });


### PR DESCRIPTION
A `space` is required~
