### PR TITLE
chore: should has no default export

### DIFF
--- a/should.d.ts
+++ b/should.d.ts
@@ -240,4 +240,4 @@ declare global {
 
 export as namespace should;
 
-export = should;
+export default should;


### PR DESCRIPTION
Language: TypeScript

In version 12.0.0 we used to import should like this
```typescript
import * as should from "should"
```
Now (13.0.x), exported `should` is not an object anymore, so we have to import it this way.
```typescript
import should from "should"
```
But Typescript says that it has no default export.

This PR fixes this issue.