### PR TITLE
Add message? to [Tt]rue and [Ff]alse so they can be used in ts tests

### DIFF
--- a/should.d.ts
+++ b/should.d.ts
@@ -73,11 +73,11 @@ declare namespace should {
     only: this;
 
     // bool
-    true(): this;
-    True(): this;
+    true(message?: string): this;
+    True(message?: string): this;
 
-    false(): this;
-    False(): this;
+    false(message?: string): this;
+    False(message?: string): this;
 
     ok(): this;
 


### PR DESCRIPTION
Having the optional parameter (message) in true() / false() is very useful when you want to say something failed.

The problem is that this cannot be used in typescript because the `.d.ts` does not allow the optional parameter to be used in typescript tests.

This PR simply updates `should.d.ts` to specify an optional string parameter `(message?: string)` 