### PR TITLE
fix(should.d.ts): remove subsequent declaration

### DIFF
--- a/should.d.ts
+++ b/should.d.ts
@@ -232,12 +232,6 @@ declare namespace should {
   interface PromisedAssertion extends Assertion, PromiseLike<any> {}
 }
 
-declare global {
-  interface Object {
-    should: should.Assertion;
-  }
-}
-
 export as namespace should;
 
 export = should;


### PR DESCRIPTION
The subsequent declaration is redundant and incorrect. See https://stackoverflow.com/a/48705389/1825329

fixes issue #147