### PR TITLE
Fix TypeScript compiler issue with fulfilled assertion

### DIFF
--- a/should.d.ts
+++ b/should.d.ts
@@ -163,9 +163,9 @@ declare namespace should {
     //promise
     Promise(): this;
 
-    fulfilled: Promise<any>;
-    resolved: Promise<any>;
-    rejected: Promise<any>;
+    fulfilled(): Promise<any>;
+    resolved(): Promise<any>;
+    rejected(): Promise<any>;
 
     fulfilledWith(obj: any): Promise<any>;
     resolvedWith(obj: any): Promise<any>;


### PR DESCRIPTION
Without this, a standard assertion like 
```ts
return (new Promise(null)).should.be.fulfilled();
```
would fail with a `error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'Promise<any>' has no compatible call signatures.` compiler error.