### PR TITLE
fix(should.d.ts): remove subsequent declaration

### DIFF
--- a/should.d.ts
+++ b/should.d.ts
@@ -232,12 +232,6 @@ declare namespace should {
   interface PromisedAssertion extends Assertion, PromiseLike<any> {}
 }
 
-declare global {
-  interface Object {
-    should: should.Assertion;
-  }
-}
-
 export as namespace should;
 
 export = should;


### PR DESCRIPTION
Fixes error: 
```
node_modules/@types/should/index.d.ts(7,3): error TS2403: Subsequent variable declarations must have the same type.  Variable 'should' must be of type 'Assertion', but here has type 'ShouldAssertion'.
```
See [stackoverflow](https://stackoverflow.com/questions/48704927/same-types-but-still-error-on-global-declaration-ts2717-subsequent-property-de/48705389#48705389).

Fixes issue: [#147](https://github.com/shouldjs/should.js/issues/147).