### PR TITLE
Add .truthy and .falsy

### DIFF
--- a/lib/ext/bool.js
+++ b/lib/ext/bool.js
@@ -68,4 +68,45 @@ export default function(should, Assertion) {
 
     this.assert(this.obj);
   });
+
+  /**
+   * Assert given object is truthy according javascript type conversions.
+   *
+   * @name truthy
+   * @memberOf Assertion
+   * @category assertion bool
+   * @example
+   *
+   * (true).should.be.truthy();
+   * ''.should.not.be.truthy();
+   * should(null).not.be.truthy();
+   * should(void 0).not.be.truthy();
+   *
+   * (10).should.be.truthy();
+   * (0).should.not.be.truthy();
+   */
+  Assertion.alias("ok", "truthy");
+
+
+  /**
+   * Assert given object is falsy according javascript type conversions.
+   *
+   * @name falsy
+   * @memberOf Assertion
+   * @category assertion bool
+   * @example
+   *
+   * (false).should.be.falsy();
+   * ''.should.be.falsy();
+   * should(null).be.falsy();
+   * should(void 0).be.falsy();
+   *
+   * (10).should.not.be.falsy();
+   * (0).should.be.falsy();
+   */
+  Assertion.add('falsy', function() {
+    this.assertZeroArguments(arguments);
+    this.params = { operator: 'to be falsy' };
+    this.assert(!this.obj);
+  });
 }

--- a/should.d.ts
+++ b/should.d.ts
@@ -80,6 +80,8 @@ declare namespace should {
     False(message?: string): this;
 
     ok(): this;
+    truthy(): this;
+    falsy(): this;
 
     //chain
     an: this;

--- a/test.ts
+++ b/test.ts
@@ -66,6 +66,12 @@ false.should.not.be.ok();
 "".should.not.be.ok();
 (0).should.not.be.ok();
 
+"wee".should.be.truthy();
+should(-2).be.truthy();
+
+(0).should.be.falsy();
+should(null).be.falsy();
+
 true.should.be.true();
 true.should.be.True();
 "1".should.not.be.true();

--- a/test/ext/bool.test.js
+++ b/test/ext/bool.test.js
@@ -50,5 +50,51 @@ describe("bool", function() {
     err(function() {
       "test".should.not.be.ok();
     }, "expected 'test' not to be truthy (false negative fail)");
+
+    err(function() {
+      "hello".should.be.ok(true);
+    }, "This assertion does not expect any arguments. You may need to check your code");
+  });
+
+  it("test truthy", function() {
+    true.should.be.truthy();
+    false.should.not.be.truthy();
+    (1).should.be.truthy();
+    (0).should.not.be.truthy();
+    ({}).should.be.truthy();
+    (function() {}).should.be.truthy();
+
+    err(function() {
+      "".should.be.truthy();
+    }, "expected '' to be truthy");
+
+    err(function() {
+      "test".should.not.be.truthy();
+    }, "expected 'test' not to be truthy (false negative fail)");
+
+    err(function() {
+      "hello".should.be.truthy(true);
+    }, "This assertion does not expect any arguments. You may need to check your code");
+  });
+
+  it("test falsy", function() {
+    true.should.not.be.falsy();
+    false.should.be.falsy();
+    (1).should.not.be.falsy();
+    (0).should.be.falsy();
+    ({}).should.not.be.falsy();
+    (function() {}).should.not.be.falsy();
+
+    err(function() {
+      "".should.not.be.falsy();
+    }, "expected '' not to be falsy (false negative fail)");
+
+    err(function() {
+      "test".should.be.falsy();
+    }, "expected 'test' to be falsy");
+
+    err(function() {
+      "".should.be.falsy(false);
+    }, "This assertion does not expect any arguments. You may need to check your code");
   });
 });


### PR DESCRIPTION
This PR adds `.truthy` as an alias to `.ok`, and compliments it with a new `.falsy` assertion.

They're both trivial to add on your own, of course. But I think that the use case is common enough to warrant inclusion in the main library, as `.truthy` and `.falsy` reads better than `.ok` and `.not.ok`.