### PR TITLE
Fix: Readme for Typescript Instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,8 +70,8 @@ someAsyncTask(foo, function(err, result){
     should(10).be.exactly(5).and.be.a.Number();
     ```
 
-  3. For TypeScript users:
-
+ 3. For TypeScript users:
+  
     ```js
     import * as should from 'should';
 


### PR DESCRIPTION
This PR fixes the TypeScript Instructions display in Readme.

Before:

<img width="793" alt="screenshot 2019-03-07 at 5 30 32 pm" src="https://user-images.githubusercontent.com/9017518/53955373-df13d300-40fe-11e9-9d14-3e0bf3bdf83a.png">

Now:

<img width="471" alt="screenshot 2019-03-07 at 5 32 27 pm" src="https://user-images.githubusercontent.com/9017518/53955434-023e8280-40ff-11e9-9ff4-3e300ade3067.png">
