### PR TITLE
Fix throws `TypeError` when passing an arrow function

### DIFF
--- a/lib/ext/_assert.js
+++ b/lib/ext/_assert.js
@@ -206,7 +206,7 @@ function expectedException(actual, expected) {
 
   if (Object.prototype.toString.call(expected) == "[object RegExp]") {
     return expected.test(actual);
-  } else if (actual instanceof expected) {
+  } else if (expected.prototype && actual instanceof expected) {
     return true;
   } else if (expected.call({}, actual) === true) {
     return true;

--- a/test/ext/assert.test.js
+++ b/test/ext/assert.test.js
@@ -251,6 +251,9 @@ describe("assert", function() {
     );
     threw = false;
 
+    // if passing a arrow function, catch all
+    assert.throws(makeBlock(thrower, TypeError), () => true);
+
     // doesNotThrow should pass through all errors
     try {
       assert.doesNotThrow(makeBlock(thrower, TypeError), assert.AssertionError);


### PR DESCRIPTION
Codes like this:
```js
    should.throws(
      () => {
        throw new Error();
      },
      () => true
    );
```
won't work:
```bash
TypeError: Function has non-object prototype 'undefined' in instanceof check
```